### PR TITLE
:sparkles: support ARM64 on linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
         go generate
         GOOS=darwin CGO_ENABLED=0 GOARCH=arm64 go build -o synq-dbt-arm64-darwin main.go
         GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -o synq-dbt-amd64-linux main.go
+        GOOS=linux CGO_ENABLED=0 GOARCH=arm64 go build -o synq-dbt-arm64-linux main.go
         GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o synq-dbt-amd64-windows.exe main.go
     - name: Release
       if: startsWith(github.ref, 'refs/tags/')
@@ -38,6 +39,7 @@ jobs:
         files: |
          synq-dbt-arm64-darwin
          synq-dbt-amd64-linux
+         synq-dbt-arm64-linux
          synq-dbt-amd64-windows.exe
 name: release synq-dbt
 "on":


### PR DESCRIPTION
This pull request adds a new build target for the `synq-dbt` binary on Linux machines with arm64 architecture and includes the `synq-dbt-arm64-linux` binary in the release artifacts.

Main changes:

* <a href="diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR33">`.github/workflows/release.yaml`</a>: Added a new build target for the `synq-dbt` binary on Linux machines with arm64 architecture and included the `synq-dbt-arm64-linux` binary in the release artifacts.