### PR TITLE
Fix dbt process termination when airflow task is killed

### DIFF
--- a/command/helpers.go
+++ b/command/helpers.go
@@ -88,8 +88,14 @@ func ExecuteCommand(ctx context.Context, cmdName string, args ...string) (exitCo
 	if err != nil {
 		if errors.As(err, &exitError) {
 			return exitError.ExitCode(), outb.Bytes(), errb.Bytes(), err
+			}
 		}
+
+		return 0, outb.Bytes(), errb.Bytes(), nil
 	}
 
-	return 0, outb.Bytes(), errb.Bytes(), nil
+func terminateProcessGroup(ctx context.Context, cmd *exec.Cmd) {
+	<-ctx.Done()
+	logrus.Println("terminating process group", cmd.Process.Pid)
+	syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }

--- a/forever.sh
+++ b/forever.sh
@@ -3,6 +3,8 @@
 echo "forever.sh pid: $$"
 echo "forever.sh pgid: $(ps -o pgid= $$)"
 
+trap "echo 'forever.sh received termination signal'; exit" SIGINT SIGTERM
+
 while true; do
   echo "Press [CTRL+C] to stop.."
   sleep 1


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/getsynq/synq-dbt/pull/10?shareId=7304b5af-1ffc-424e-92e2-8bbc7115ea20).