### PR TITLE
Add token migration and regional endpoint documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,29 @@ dbt build | tee dbt.log
 
 To successfully install and launch `synq-dbt` you will need `SYNQ_TOKEN` secret, that you generate in your SYNQ account when integrating with dbt Core. Reach out to the team if you have any questions. It should be treated as a secret as it allows SYNQ to identify you as the customer and associate uploaded data with your workspace.
 
+## Token Format
+
+**Important:** If your `SYNQ_TOKEN` doesn't start with `st-`, you're using a legacy token that will be deprecated. Legacy tokens (in any format different than `st-XXXXXXX`) must be updated to the new format for continued compatibility.
+
+To upgrade your token:
+1. Ensure you're using `synq-dbt` version 1.8.0 or later
+2. Generate a new v2 token in your SYNQ settings
+3. Replace your existing `SYNQ_TOKEN` environment variable with the new token starting with `st-`
+
+The new v2 tokens provide improved security and performance. Legacy tokens will continue working during the transition period, but we recommend proactively migrating to maintain compatibility with future SYNQ integrations.
+
+## Regional API Endpoints
+
+By default, `synq-dbt` connects to the European region API endpoint. If your SYNQ workspace is in the **US region**, you must:
+
+1. Use `synq-dbt` version 1.8.0 or newer
+2. Use only new v2 tokens (tokens starting with `st-`) - legacy tokens are not supported for US region
+3. Set the `SYNQ_API_ENDPOINT` environment variable:
+
+```bash
+export SYNQ_API_ENDPOINT=https://api.us.synq.io
+```
+
 ## Airflow
 
 We will cover two most common setups of dbt and Airflow:

--- a/synq/upload.go
+++ b/synq/upload.go
@@ -13,9 +13,9 @@ import (
 )
 
 func UploadArtifacts(ctx context.Context, dbtResult *v1.DbtResult, token string, targetDirectory string) {
-	synqV1ApiEndpoint, ok := os.LookupEnv("SYNQ_UPLOAD_URL")
-	if !ok {
-		synqV1ApiEndpoint = "dbtapi.synq.io:443"
+	synqV1ApiEndpoint := "dbtapi.synq.io:443"
+	if envEndpoint, ok := os.LookupEnv("SYNQ_UPLOAD_URL"); ok {
+		synqV1ApiEndpoint = envEndpoint
 	}
 	synqV2ApiEndpoint := "https://developer.synq.io/"
 	if envEndpoint, ok := os.LookupEnv("SYNQ_API_ENDPOINT"); ok {


### PR DESCRIPTION
## Summary
- Document deprecated legacy tokens and migration requirements to v2 tokens
- Add instructions for upgrading to v2 tokens (st-XXXXXXX format) 
- Document US region requirements: v1.8.0+ and v2 tokens only
- Add SYNQ_API_ENDPOINT configuration for US region

## Test plan
- [ ] Review documentation changes for clarity and accuracy
- [ ] Verify token format examples are correct
- [ ] Confirm US region requirements match current system behavior

🤖 Generated with [Claude Code](https://claude.ai/code)